### PR TITLE
Update main.less with less annoyances

### DIFF
--- a/main.less
+++ b/main.less
@@ -1,14 +1,14 @@
-@font-size: 1.2em;
-@color: #aaa;
+@font-size: 20px;
+@color: #ffb74d;
 
 .CodeMirror-foldgutter {
 	&-open:after {
-    	content: "\25bc";
+    	content: "\2296";
 		font-size: @font-size;
 		color: @color;
 	}
 	&-folded:after {
-    	content: "\25b6";
+    	content: "\2295";
 		font-size: @font-size;
 		color: @color;
 	}
@@ -18,9 +18,11 @@
 .CodeMirror-foldgutter-open,
 .CodeMirror-foldgutter-folded,
 .CodeMirror-foldgutter-blank {
-    width: @font-size;
-    cursor: default;
-    line-height: 100%;
+	cursor: pointer;
+	margin-left: 7px;
+        width: @font-size;
+    	line-height: 100%;
+	font-weight: 600;
 }
 
 .CodeMirror-gutter-elt {
@@ -28,18 +30,15 @@
 }
 
 .CodeMirror-foldmarker {
+    font-weight: 600;
     padding-right: 5px;
     padding-left: 5px;
     margin-right: 3px;
     margin-left: 3px;
-    border-radius: 3px;
-    cursor: pointer;
-	border: 1px solid lighten(@color, 10%);
-	color: darken(@color, 20%);
-	background-color: lighten(@color, 20%);
+    color: darken(@color, 2%);
     
     &:after {
-        content: "\2194";   
+        content: "...";   
     }
 }
 


### PR DESCRIPTION

![screenshot 25](https://cloud.githubusercontent.com/assets/9140532/6410955/f4a1d846-be73-11e4-8957-8f48b54df18d.png)
![screenshot 26](https://cloud.githubusercontent.com/assets/9140532/6410956/f4a64552-be73-11e4-9db3-6c0a3a817dd8.png)

The margin between the editor and the codemarker icon is too close so the pointer doesn't show up, tried fixing that.

Replaced the Codemarker icons with the unicode circled plus ⊕ and minus ⊖ ones, I think they feel a lot intuitive and replaced the fold marker icon with minimalistic three dots "..."

Replaced the colours of the icons with material orange instead of white/grey for those using a Brackets light theme.